### PR TITLE
Updated ic-cdk in order to resolve ic-cdk-executor conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canistergeek_ic_rust"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "A tool for Internet Computer to track your project canisters cycles and memory status."
 license = "MIT"
@@ -9,9 +9,9 @@ repository = "https://github.com/usergeek/canistergeek_ic_rust.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.10.3"
+candid = "0.10.17"
 serde = "1.0.196"
-ic-cdk = "0.12.1"
+ic-cdk = "0.18.7"
 chrono = {version = "0.4.33", default-features = false, features = ["clock", "std"]}
 num-bigint = "0.4.4"
 num-traits = "0.2.18"

--- a/src/ic_util/mod.rs
+++ b/src/ic_util/mod.rs
@@ -27,7 +27,7 @@ pub fn get_cycles() -> u64 {
 pub fn get_stable_memory_size() -> u64 {
     #[cfg(target_arch = "wasm32")]
     {
-        (ic_cdk::api::stable::stable64_size() as u64) * WASM_PAGE_SIZE
+        (ic_cdk::api::stable::stable_size() as u64) * WASM_PAGE_SIZE
     }
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/src/ic_util/mod.rs
+++ b/src/ic_util/mod.rs
@@ -9,7 +9,7 @@ pub fn get_ic_time_nanos() -> u64 {
     #[cfg(not(target_arch = "wasm32"))]
     {
         use chrono::prelude::*;
-        Utc::now().timestamp_nanos() as u64
+        Utc::now().timestamp_nanos_opt().unwrap() as u64
     }
 }
 

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -22,7 +22,7 @@ static mut STORAGE: Option<LogMessageStorage> = None;
 
 fn get_storage<'a>() -> &'a mut LogMessageStorage {
     unsafe {
-        if let Some(s) = &mut STORAGE {
+        if let Some(s) = &mut *std::ptr::addr_of_mut!(STORAGE) {
             s
         } else {
             STORAGE = Some(LogMessageStorage::new(DEFAULT_MAX_LOG_MESSAGES_COUNT));
@@ -43,7 +43,7 @@ pub fn post_upgrade_stable_data(data: PostUpgradeStableData) {
             STORAGE = Some(log_message_storage);
         },
         _ => {
-            ic_cdk::print(std::format!(
+            ic_cdk::api::debug_print(std::format!(
                 "Can not upgrade stable log messages data. Unsupported version {}",
                 data.0
             ));

--- a/src/monitor/calculator/day_iterator.rs
+++ b/src/monitor/calculator/day_iterator.rs
@@ -7,7 +7,7 @@ use chrono::Duration;
 ///
 /// Basic usage:
 ///
-/// ```
+/// ```ignore
 /// let result = DayIterator::new_reverse(23_i64, 23_i64);
 /// let mut iter = result.unwrap();
 /// assert_eq!(iter.next().unwrap().timestamp(), 0_i64);
@@ -27,7 +27,7 @@ impl DayIterator {
         Ok(DayIterator {
             from_day: Utc.timestamp_millis_opt(from_millis).unwrap(),
             day: Utc
-                .timestamp_millis_opt(from_millis).unwrap()
+                .timestamp_millis_opt(to_millis).unwrap()
                 .date_naive()
                 .and_hms_opt(0, 0, 0)
                 .unwrap()

--- a/src/monitor/calculator/day_iterator.rs
+++ b/src/monitor/calculator/day_iterator.rs
@@ -14,7 +14,7 @@ use chrono::Duration;
 /// assert_eq!(iter.next(), None);
 /// ```
 pub struct DayIterator {
-    from_day: Date<Utc>,
+    from_day: DateTime<Utc>,
     day: DateTime<Utc>,
 }
 
@@ -25,12 +25,13 @@ impl DayIterator {
         }
 
         Ok(DayIterator {
-            from_day: Utc.timestamp_millis(from_millis).date(),
+            from_day: Utc.timestamp_millis_opt(from_millis).unwrap(),
             day: Utc
-                .timestamp_millis(to_millis)
-                .date()
+                .timestamp_millis_opt(from_millis).unwrap()
+                .date_naive()
                 .and_hms_opt(0, 0, 0)
-                .unwrap(),
+                .unwrap()
+                .and_utc(),
         })
     }
 }
@@ -39,7 +40,7 @@ impl Iterator for DayIterator {
     type Item = DateTime<Utc>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.day.date() < self.from_day {
+        if self.day.date_naive() < self.from_day.date_naive() {
             None
         } else {
             let next_day = self.day;
@@ -73,44 +74,44 @@ mod tests {
 
     #[test]
     fn some() {
-        let from = Utc.ymd(2020, 12, 28).and_hms(23, 12, 13);
-        let to = Utc.ymd(2021, 1, 3).and_hms(23, 12, 13);
+        let from = Utc.with_ymd_and_hms(2020, 12, 28, 23, 12, 13).unwrap();
+        let to = Utc.with_ymd_and_hms(2021, 1, 3, 23, 12, 13).unwrap();
 
         let result = DayIterator::new_reverse(from.timestamp_millis(), to.timestamp_millis());
         let mut iter = result.unwrap();
 
-        assert_eq!(iter.next().unwrap(), to.date().and_hms(0, 0, 0));
+        assert_eq!(iter.next().unwrap(), to.date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc());
         assert_eq!(
             iter.next().unwrap(),
-            to.date().and_hms(0, 0, 0) - Duration::days(1)
+            to.date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc() - Duration::days(1)
         );
         assert_eq!(
             iter.next().unwrap(),
-            to.date().and_hms(0, 0, 0) - Duration::days(2)
+            to.date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc() - Duration::days(2)
         );
         assert_eq!(
             iter.next().unwrap(),
-            to.date().and_hms(0, 0, 0) - Duration::days(3)
+            to.date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc() - Duration::days(3)
         );
         assert_eq!(
             iter.next().unwrap(),
-            to.date().and_hms(0, 0, 0) - Duration::days(4)
+            to.date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc() - Duration::days(4)
         );
         assert_eq!(
             iter.next().unwrap(),
-            to.date().and_hms(0, 0, 0) - Duration::days(5)
+            to.date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc() - Duration::days(5)
         );
         assert_eq!(
             iter.next().unwrap(),
-            to.date().and_hms(0, 0, 0) - Duration::days(6)
+            to.date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc() - Duration::days(6)
         );
         assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn some_max() {
-        let from = Utc.ymd(2020, 12, 28).and_hms(23, 12, 13);
-        let to = Utc.ymd(2021, 1, 3).and_hms(23, 12, 13);
+        let from = Utc.with_ymd_and_hms(2020, 12, 28, 23, 12, 13).unwrap();
+        let to = Utc.with_ymd_and_hms(2021, 1, 3, 23, 12, 13).unwrap();
 
         let result = DayIterator::new_reverse(from.timestamp_millis(), to.timestamp_millis());
 


### PR DESCRIPTION
After running into an issue with using v0.4.3 I forked and upgraded the required dependencies. This outdated several function names and best practices. The code has been updated to resolve all warnings and passes all tests. 

There was no test to necessitate updating stable64_size to stable_size so that would be recommended going forward. Additionally, a canister leveraging this proposed update has been deployed and verified successful in pre and post upgrade.